### PR TITLE
Mobile sidebar link click should close the sidebar

### DIFF
--- a/Vue_Full_Project/src/components/SidebarNavLink.vue
+++ b/Vue_Full_Project/src/components/SidebarNavLink.vue
@@ -7,8 +7,10 @@
   </div>
   <div v-else>
     <router-link :to="url" :class="classList">
-      <i :class="icon"></i> {{name}}
-      <b-badge v-if="badge && badge.text" :variant="badge.variant">{{badge.text}}</b-badge>
+      <span @click="hideMobile">
+        <i :class="icon"></i> {{name}}
+        <b-badge v-if="badge && badge.text" :variant="badge.variant">{{badge.text}}</b-badge>
+      </span>
     </router-link>
   </div>
 </template>
@@ -52,6 +54,13 @@
       },
       linkExternal () {
         return isExternal(this.url)
+      }
+    },
+    methods: {
+      hideMobile () {
+        if (document.body.classList.contains('sidebar-mobile-show')) {
+          document.body.classList.toggle('sidebar-mobile-show')
+        }
       }
     }
   }


### PR DESCRIPTION
When a mobile user clicks a link in the sidebar, it should close that sidebar for mobile users.
The reason is that the "default" mobile experience ought to be menu-less or content will flow off the screen.